### PR TITLE
Allow to ship this gem with precompiled binaries

### DIFF
--- a/.github/workflows/cibuildgem.yaml
+++ b/.github/workflows/cibuildgem.yaml
@@ -1,0 +1,87 @@
+name: "Package and release gems with precompiled binaries"
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: "If the whole build passes on all platforms, release the gems on RubyGems.org"
+        required: false
+        type: boolean
+        default: false
+jobs:
+  compile:
+    timeout-minutes: 20
+    name: "Cross compile the gem on different ruby versions"
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-22.04", "ubuntu-22.04-arm", "windows-latest", "macos-15-intel"]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v5"
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "3.1.7"
+          bundler-cache: true
+      - name: "Run cibuildgem"
+        uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
+        with:
+          step: "compile"
+  test:
+    timeout-minutes: 20
+    name: "Run the test suite"
+    needs: compile
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-22.04", "ubuntu-22.04-arm", "windows-latest", "macos-15-intel"]
+        rubies: ["3.1", "3.2", "3.3", "3.4"]
+        type: ["cross", "native"]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v5"
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "${{ matrix.rubies }}"
+          bundler-cache: true
+      - name: "Run cibuildgem"
+        uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
+        with:
+          step: "test_${{ matrix.type }}"
+  install:
+    timeout-minutes: 5
+    name: "Verify the gem can be installed"
+    needs: test
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-22.04", "ubuntu-22.04-arm", "windows-latest", "macos-15-intel"]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "3.4.7"
+      - name: "Run cibuildgem"
+        uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
+        with:
+          step: "install"
+  release:
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    timeout-minutes: 5
+    if: ${{ inputs.release }}
+    name: "Release all gems with RubyGems"
+    needs: install
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "3.4.7"
+      - name: "Run cibuildgem"
+        uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
+        with:
+          step: "release"

--- a/lib/dedup.rb
+++ b/lib/dedup.rb
@@ -55,9 +55,16 @@ module Dedup
 end
 
 begin
-  require "dedup/dedup"
-  Dedup::Native.extend(Dedup::Native)
-  Dedup.extend(Dedup::Native)
+  require "dedup/#{RUBY_VERSION[/^\d+\.\d+/]}/dedup"
 rescue LoadError
-  Dedup.extend(Dedup::Ruby)
+  begin
+    require "dedup/dedup"
+  rescue LoadError
+    Dedup.extend(Dedup::Ruby)
+  end
+ensure
+  if defined?(Dedup::Native)
+    Dedup::Native.extend(Dedup::Native)
+    Dedup.extend(Dedup::Native)
+  end
 end


### PR DESCRIPTION
TL;DR I'd like to propose releasing this gem with precompiled binaries built for different platforms and different ABI version (fat gem).

This is the workflow that would run once we want to cut a release https://github.com/Shopify/dedup/actions/runs/20052542210

I'm currently working on a tool to help the Ruby community ship gems with precompiled binaries with the intent to make `bundle install` much faster for everyone. The main bottleneck when installing gems in a project is the compilation of native extensions.

[cibuildgem](https://github.com/Shopify/cibuildgem) modestly tries to follow the same approach as what the python community did with [cibuildwheel](https://cibuildwheel.pypa.io/en/stable/). It works with a native compilation using CI runners (GitHub it the only supported vendor for now) and tries to be as easy to setup as possible.

The CI workflow in this commit was generated with the cibuildgem CLI which reads the gemspec and determine what ruby versions needs to be compiled and tested against.