### PR TITLE
The ruby versions tested are too old:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ ruby-head, '3.1', '3.0', '2.7', '2.6', '2.5' ]
+        ruby: [ ruby-head, '3.4', '3.3', '3.2', '3.1', '3.0' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [macos, windows]
-        ruby: ['2.5']
+        ruby: ['3.2']
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
The ruby versions tested are too old:

- GitHub CI is failing because the versions are too old. Modify the test matrix to test on supported ruby versions.